### PR TITLE
add ability to post to user pantry

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,4 +4,16 @@ const fetchData = (extension) => {
     .catch(err => console.log(err));
 };
 
-export {fetchData}
+const postData = (data) => {
+  return fetch(`http://localhost:3001/api/v1/users`, {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: {
+      "Content-Type": "application/json"
+    }
+  })
+  .then(response => response.json())
+  .catch(err => console.log(err))
+};
+
+export {fetchData, postData};

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -3,6 +3,7 @@ import "./styles.css";
 import RecipeRepository from "../src/classes/RecipeRepository";
 import User from "./classes/user";
 import { fetchData } from "./apiCalls";
+import { postData } from "./apiCalls";
 import Pantry from "./classes/Pantry";
 import domUpdates from "./domUpdates";
 
@@ -72,6 +73,26 @@ function fetchAllData() {
 }
 
 fetchAllData();
+
+function postAllData(ingredient, addIngred) {
+  if (addIngred === true) {
+    let data = {
+      userID: currentUser.id,
+      ingredientID: ingredient.id,
+      ingredientModification: (ingredient.amount)* 1
+    }
+    postData(data)
+  } else {
+    let data = {
+      userID: currentUser.id,
+      ingredientID: ingredient.id,
+      ingredientModification: -(ingredient.amount)
+    }
+    console.log("what?", ingredient)
+    console.log("whwwwhwhwhwhhhaaaa", -(ingredient.amount))
+    postData(data)
+  }
+}
 
 function addFavoriteRecipe() {
   if (!currentUser.favoriteRecipes.includes(currentRecipe)) {
@@ -152,6 +173,7 @@ function searchFavoriteRecipe() {
 }
 
 const cookRecipe = () => {
+  currentRecipe.ingredientList.forEach((ingredient) => postAllData(ingredient, false)) 
   currentPantry.cookWithIngredients(currentRecipe.ingredientList);
   const currentRecipeIndex = currentUser.recipesToCook.findIndex((element) => {
     return element.id === currentRecipe.id;
@@ -223,6 +245,9 @@ listOfIngredients.addEventListener("click", function (event) {
         currentRecipe.ingredientList,
         currentPantry.determineCookAbility(currentRecipe.ingredientList)
       );
+      console.log(currentUser)
+      console.log("add", ingredient)
+      postAllData(ingredient, true)
       displayPantry();
     }
   });


### PR DESCRIPTION
## Summary:
Every time a user adds an ingredient from a recipe, or cooks a recipe, a post is sent to add/subtract the amount of ingredient from the user's pantry on the local server.

## Type of Changes:
- [ ] Bug fix
- [ ] Refactor
- [x] New feature

## Where are the Changes:
changes were made in the scripts.js and apiCalls.js files

## How was this tested:
Tested in the browser using npm start and viewing the local server

## What are the relevant tickets:
Closes #47
